### PR TITLE
feat: add getter for compute lock address

### DIFF
--- a/contracts/skipper.tact
+++ b/contracts/skipper.tact
@@ -61,4 +61,9 @@ contract Skipper with Deployable {
         let init = initOf Proposal(myAddress(), proposal_id);
         return contractAddress(init);
     }
+
+    get fun get_lock_address(owner: Address): Address {
+        let init = initOf JettonLock(owner, self.jetton_master);
+        return contractAddress(init);
+    }
 }

--- a/tests/Skipper.spec.ts
+++ b/tests/Skipper.spec.ts
@@ -224,4 +224,9 @@ describe('Integration tests', () => {
         let proposal_address = await skipper.getGetProposalAddress(1n);
         expect(proposal_address).toEqualAddress(proposal.address);
     });
+
+    it('should compute lock address', async () => {
+        let lock_address = await skipper.getGetLockAddress(deployer.address);
+        expect(lock_address).toEqualAddress(lock.address);
+    });
 });


### PR DESCRIPTION
**Summary of changes**:

Added `get_lock_address` getter. It compute Jetton Lock address for specified address. It helpful for frontend to find out needed lock address
