### PR TITLE
feat: voter prevent double init / vote

### DIFF
--- a/contracts/errors.tact
+++ b/contracts/errors.tact
@@ -24,3 +24,5 @@ const ERROR_UNLOCK_DATE_INSUFFICIENT: Int = 6910;
 const ERROR_INVALID_LOCK_PERIOD: Int = 6911;
 // Lock period is too short and does not extend the current unlock date
 const ERROR_LOCK_PERIOD_TOO_SHORT: Int = 6912;
+// Amount provided must be greater than zero
+const ERROR_CODE_INVALID_AMOUNT: Int = 6913;

--- a/contracts/errors.tact
+++ b/contracts/errors.tact
@@ -24,3 +24,5 @@ const ERROR_UNLOCK_DATE_INSUFFICIENT: Int = 6910;
 const ERROR_INVALID_LOCK_PERIOD: Int = 6911;
 // Lock period is too short and does not extend the current unlock date
 const ERROR_LOCK_PERIOD_TOO_SHORT: Int = 6912;
+// Voter has already cast their vote (to prevent double voting)
+const ERROR_CODE_VOTE_ALREADY_CASTED: Int = 6913;

--- a/contracts/errors.tact
+++ b/contracts/errors.tact
@@ -24,5 +24,3 @@ const ERROR_UNLOCK_DATE_INSUFFICIENT: Int = 6910;
 const ERROR_INVALID_LOCK_PERIOD: Int = 6911;
 // Lock period is too short and does not extend the current unlock date
 const ERROR_LOCK_PERIOD_TOO_SHORT: Int = 6912;
-// Voter has already cast their vote (to prevent double voting)
-const ERROR_CODE_VOTE_ALREADY_CASTED: Int = 6913;

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -99,7 +99,7 @@ contract Voter {
     proposal: Address;
     owner: Address;
     is_initialized: Bool = false;
-
+    voted: Bool = false;
     amount: Int = 0;
 
     init(master: Address, proposal: Address, owner: Address){
@@ -108,16 +108,26 @@ contract Voter {
         self.owner = owner;
     }
 
+    fun initialize(amount: Int) {
+        self.is_initialized = true;
+        self.amount = amount;
+    }
+
     receive(msg: InitVoter){
         nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
-        self.is_initialized = true;
-        self.amount = msg.amount;
+        self.initialize(msg.amount);
     }
 
-    receive(msg: UpdateVoterBalance){
-        nativeThrowUnless(ERROR_NOT_INITIALIZED, self.is_initialized);
-        nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);       
+    receive(msg: UpdateVoterBalance){   
+        nativeThrowUnless(ERROR_CODE_VOTE_ALREADY_CASTED, self.voted);             
+        nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
+        if (!self.is_initialized) {
+            self.initialize(msg.amount);
+        }
+
+        self.voted = true;
+
         send(SendParameters{
                 to: self.proposal,
                 value: 0,

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -117,21 +117,24 @@ contract Voter {
     receive(msg: UpdateVoterBalance){   
         nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, msg.amount <= 0);             
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
+        
+        let newAmount = msg.amount - self.amount;
+        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, newAmount <= 0);
+
         self.is_initialized = true;
-        self.amount += msg.amount;
+        self.amount = msg.amount;
 
         send(SendParameters{
-                to: self.proposal,
-                value: 0,
-                mode: SendRemainingValue,
-                body: UpdateVotes{
-                    owner: self.owner, 
-                    amount: msg.amount,
-                    vote: msg.vote,
-                    voter_unlock_date: msg.voter_unlock_date
-                }.toCell()
-            }
-        );
+            to: self.proposal,
+            value: 0,
+            mode: SendRemainingValue,
+            body: UpdateVotes{
+                owner: self.owner, 
+                amount: newAmount, // Send only the difference
+                vote: msg.vote,
+                voter_unlock_date: msg.voter_unlock_date
+            }.toCell()
+        });
     }
 
     get fun get_voter_amount(): Int {

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -98,7 +98,10 @@ contract Voter {
     master: Address;
     proposal: Address;
     owner: Address;
+    is_initialized: Bool = false;
+
     amount: Int = 0;
+
     init(master: Address, proposal: Address, owner: Address){
         self.master = master;
         self.proposal = proposal;
@@ -106,12 +109,14 @@ contract Voter {
     }
 
     receive(msg: InitVoter){
-        // TODO check already initialized
+        nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
+        self.is_initialized = true;
         self.amount = msg.amount;
     }
 
     receive(msg: UpdateVoterBalance){
+        nativeThrowUnless(ERROR_NOT_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);       
         send(SendParameters{
                 to: self.proposal,

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -99,7 +99,6 @@ contract Voter {
     proposal: Address;
     owner: Address;
     is_initialized: Bool = false;
-    voted: Bool = false;
     amount: Int = 0;
 
     init(master: Address, proposal: Address, owner: Address){
@@ -117,17 +116,12 @@ contract Voter {
         nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
         self.initialize(msg.amount);
-        self.voted = true;
     }
 
     receive(msg: UpdateVoterBalance){   
-        nativeThrowIf(ERROR_CODE_VOTE_ALREADY_CASTED, self.voted);             
+        nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);             
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
-        if (!self.is_initialized) {
-            self.initialize(msg.amount);
-        }
-
-        self.voted = true;
+        self.initialize(msg.amount);        
 
         send(SendParameters{
                 to: self.proposal,

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -117,6 +117,7 @@ contract Voter {
         nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
         self.initialize(msg.amount);
+        self.voted = true;
     }
 
     receive(msg: UpdateVoterBalance){   

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -120,7 +120,7 @@ contract Voter {
     }
 
     receive(msg: UpdateVoterBalance){   
-        nativeThrowUnless(ERROR_CODE_VOTE_ALREADY_CASTED, self.voted);             
+        nativeThrowIf(ERROR_CODE_VOTE_ALREADY_CASTED, self.voted);             
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
         if (!self.is_initialized) {
             self.initialize(msg.amount);

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -54,6 +54,7 @@ contract Proposal {
         nativeThrowUnless(ERROR_NOT_INITIALIZED, self.is_initialized);
         nativeThrowIf(ERROR_ALREADY_EXECUTED, self.is_executed);
         nativeThrowUnless(ERROR_PROPOSAL_EXPIRED, now() < self.expires_at);
+        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, msg.amount <= 0);             
 
          // Check if unlock_date covers the proposal's expires_at
         nativeThrowUnless(ERROR_UNLOCK_DATE_INSUFFICIENT, msg.voter_unlock_date >= self.expires_at);
@@ -110,17 +111,18 @@ contract Voter {
     receive(msg: InitVoter){
         nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
+        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, msg.amount <= 0);             
+
         self.is_initialized = true;
         self.amount = msg.amount;
     }
 
     receive(msg: UpdateVoterBalance){   
         nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, msg.amount <= 0);             
-        nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
-        
-        let newAmount = msg.amount - self.amount;
-        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, newAmount <= 0);
+        nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);  
+        let newAmount = !self.is_initialized ? msg.amount : msg.amount - self.amount;
 
+        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, newAmount <= 0);
         self.is_initialized = true;
         self.amount = msg.amount;
 

--- a/contracts/proposal.tact
+++ b/contracts/proposal.tact
@@ -107,21 +107,18 @@ contract Voter {
         self.owner = owner;
     }
 
-    fun initialize(amount: Int) {
-        self.is_initialized = true;
-        self.amount = amount;
-    }
-
     receive(msg: InitVoter){
         nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.proposal);
-        self.initialize(msg.amount);
+        self.is_initialized = true;
+        self.amount = msg.amount;
     }
 
     receive(msg: UpdateVoterBalance){   
-        nativeThrowIf(ERROR_ALREADY_INITIALIZED, self.is_initialized);             
+        nativeThrowIf(ERROR_CODE_INVALID_AMOUNT, msg.amount <= 0);             
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.master);    
-        self.initialize(msg.amount);        
+        self.is_initialized = true;
+        self.amount += msg.amount;
 
         send(SendParameters{
                 to: self.proposal,
@@ -129,7 +126,7 @@ contract Voter {
                 mode: SendRemainingValue,
                 body: UpdateVotes{
                     owner: self.owner, 
-                    amount: msg.amount - self.amount,
+                    amount: msg.amount,
                     vote: msg.vote,
                     voter_unlock_date: msg.voter_unlock_date
                 }.toCell()

--- a/tests/Proposal.spec.ts
+++ b/tests/Proposal.spec.ts
@@ -95,32 +95,7 @@ describe('Proposal', () => {
                 }
             }
         );
-
-        let successUpdateVotesResult = await voter.send(
-            skipper.getSender(),
-            {
-                value: toNano("0.05"),
-            },
-            {
-                $$type: "UpdateVoterBalance",
-                vote: 1n,
-                amount: toNano("100500"),
-                voter_unlock_date: BigInt(startTime + LOCK_INTERVAL),                
-            }
-        );
-        expect(successUpdateVotesResult.transactions).toHaveTransaction({
-            from: skipper.address,
-            to: voter.address,
-            success: true,
-            op: OP_CODES.UpdateVoterBalance,
-        });
-        expect(successUpdateVotesResult.transactions).toHaveTransaction({
-            from: voter.address,
-            to: proposal.address,
-            success: true,
-            op: OP_CODES.UpdateVotes,
-        });
-
+        
         blockchain.now = blockchain.now!! + LOCK_INTERVAL + 1;
 
         let failedUpdateVotesResult = await voter.send(

--- a/tests/Proposal.spec.ts
+++ b/tests/Proposal.spec.ts
@@ -104,7 +104,7 @@ describe('Proposal', () => {
             {
                 $$type: "UpdateVoterBalance",
                 vote: 1n,
-                amount: toNano("100500"),
+                amount: toNano("100600"),
                 voter_unlock_date: BigInt(startTime + LOCK_INTERVAL),                
             }
         );
@@ -131,7 +131,7 @@ describe('Proposal', () => {
             {
                 $$type: "UpdateVoterBalance",
                 vote: 1n,
-                amount: toNano("100500"),
+                amount: toNano("100700"),
                 voter_unlock_date: BigInt(startTime + LOCK_INTERVAL),                
             }
         );

--- a/tests/Skipper.spec.ts
+++ b/tests/Skipper.spec.ts
@@ -181,7 +181,7 @@ describe('Integration tests', () => {
         const voteProposalResult = await lock.send(
             deployer.getSender(),
             {
-                value: toNano("10")
+                value: toNano("1")
             },
             {
                 $$type: 'SendProxyMessage',

--- a/tests/Skipper.spec.ts
+++ b/tests/Skipper.spec.ts
@@ -138,11 +138,50 @@ describe('Integration tests', () => {
         // TODO validate proposal data payload
     });
 
-    it('should vote for proposal', async () => {
+    it('should increase vote for proposal', async () => {
+
+        //Mint some jettons
+        await jetton_master.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano('500'),
+                destination: deployer.address,
+            }
+        );
+        const jettonWalletData = await jetton_wallet.getGetWalletData();
+        expect(jettonWalletData.balance).toEqual(toNano('500'));   
+        
+        //lock them
+        await jetton_wallet.send(
+            deployer.getSender(),
+            {
+                value: toNano('0.1'),
+            },
+            {
+                $$type: 'JettonTransfer',
+                query_id: 0n,
+                amount: toNano("500"),
+                destination: lock.address,
+                custom_payload: null,
+                forward_payload: beginCell().asSlice(),
+                forward_ton_amount: toNano("0.05"),
+                response_destination: lock.address,
+            }
+        );
+
+        const lockData = await lock.getGetLockData();
+        expect(lockData.amount).toEqual(toNano('1337500'));
+
+        //Increase vote
         const voteProposalResult = await lock.send(
             deployer.getSender(),
             {
-                value: toNano("1")
+                value: toNano("10")
             },
             {
                 $$type: 'SendProxyMessage',

--- a/tests/Skipper.spec.ts
+++ b/tests/Skipper.spec.ts
@@ -11,21 +11,28 @@ import { EXIT_CODES, LOCK_INTERVAL, OP_CODES } from './constants';
 describe('Integration tests', () => {
     let blockchain: Blockchain;
     let deployer: SandboxContract<TreasuryContract>;
+    let user2: SandboxContract<TreasuryContract>;
     let jetton_master: SandboxContract<JettonMaster>;
     let jetton_wallet: SandboxContract<JettonWallet>;
+    let user2_jetton_wallet: SandboxContract<JettonWallet>;
     let skipper: SandboxContract<Skipper>;
     let lock: SandboxContract<JettonLock>;
+    let user2_lock: SandboxContract<JettonLock>;
     let proposal: SandboxContract<Proposal>;
 
     beforeAll(async () => {
         blockchain = await Blockchain.create();
 
         deployer = await blockchain.treasury('deployer');
+        user2 = await blockchain.treasury('user2');
 
         jetton_master = blockchain.openContract(await JettonMaster.fromInit(deployer.address));
         jetton_wallet = blockchain.openContract(await JettonWallet.fromInit(jetton_master.address, deployer.address));
+        user2_jetton_wallet = blockchain.openContract(await JettonWallet.fromInit(jetton_master.address, user2.address));
+
         skipper = blockchain.openContract(await Skipper.fromInit(jetton_master.address));
         lock = blockchain.openContract(await JettonLock.fromInit(deployer.address, jetton_master.address));
+        user2_lock = blockchain.openContract(await JettonLock.fromInit(user2.address, jetton_master.address));
         proposal = blockchain.openContract(await Proposal.fromInit(skipper.address, 1n));
 
         const deployResult = await skipper.send(
@@ -88,6 +95,56 @@ describe('Integration tests', () => {
         );
         const lockData = await lock.getGetLockData();
         expect(lockData.amount).toEqual(toNano('1337000'));
+
+
+
+          //Setup user2 (deployer) accounts 
+        //==========================================
+        await jetton_master.send(
+            deployer.getSender(),
+            {
+                value: toNano("0.05"),
+            },
+            {
+                $$type: 'JettonMint',
+                query_id: 0n,
+                amount: toNano('1337000'),
+                destination: user2.address,
+            }
+        );
+        const jettonWalletUser2Data = await user2_jetton_wallet.getGetWalletData();
+        expect(jettonWalletUser2Data.balance).toEqual(toNano('1337000'));      
+
+        await user2_lock.send(
+            user2.getSender(),
+            {
+                value: toNano('0.05')
+            },
+            {
+                $$type: 'Deploy',
+                queryId: 0n,
+            }
+        );        
+
+        await user2_jetton_wallet.send(
+            user2.getSender(),
+            {
+                value: toNano('0.1'),
+            },
+            {
+                $$type: 'JettonTransfer',
+                query_id: 0n,
+                amount: toNano("1337000"),
+                destination: user2_lock.address,
+                custom_payload: null,
+                forward_payload: beginCell().asSlice(),
+                forward_ton_amount: toNano("0.05"),
+                response_destination: user2_lock.address,
+            }
+        );
+
+        const lockUser2Data = await user2_lock.getGetLockData();
+        expect(lockUser2Data.amount).toEqual(toNano('1337000'));
     });
 
     
@@ -138,16 +195,16 @@ describe('Integration tests', () => {
         // TODO validate proposal data payload
     });
 
-    it('should vote for proposal', async () => {
-        const voteProposalResult = await lock.send(
-            deployer.getSender(),
+    it('should vote for proposal with user2', async () => {
+        const voteProposalResult = await user2_lock.send(
+            user2.getSender(),
             {
                 value: toNano("1")
             },
             {
                 $$type: 'SendProxyMessage',
                 to: skipper.address,
-                lock_period: BigInt(LOCK_INTERVAL),
+                lock_period:  BigInt(LOCK_INTERVAL),
                 payload: beginCell()
                     .storeUint(OP_CODES.VoteForProposal, 32)
                     .storeUint(1, 64)
@@ -156,28 +213,23 @@ describe('Integration tests', () => {
             }
         );
         expect(voteProposalResult.transactions).toHaveTransaction({
-            from: deployer.address,
-            to: lock.address,
+            from: user2.address,
+            to: user2_lock.address,
             success: true,
             op: OP_CODES.SendProxyMessage,
         });
         expect(voteProposalResult.transactions).toHaveTransaction({
-            from: lock.address,
+            from: user2_lock.address,
             to: skipper.address,
             success: true,
             op: OP_CODES.ProxyMessage,
         });
+
         expect(voteProposalResult.transactions).toHaveTransaction({
             from: skipper.address,
             // to: voter.address,
             success: true,
             op: OP_CODES.UpdateVoterBalance,
-        });
-        expect(voteProposalResult.transactions).toHaveTransaction({
-            // from: voter.address,
-            to: proposal.address,
-            success: true,
-            op: OP_CODES.UpdateVotes,
         });
     });
 

--- a/tests/Voter.spec.ts
+++ b/tests/Voter.spec.ts
@@ -1,17 +1,130 @@
 import { Blockchain, SandboxContract, TreasuryContract } from '@ton/sandbox';
+import {  toNano } from '@ton/core';
 import '@ton/test-utils';
+import { EXIT_CODES, OP_CODES } from './constants';
+import { Voter } from '../wrappers/Voter';
 
 describe('Voter', () => {
     let blockchain: Blockchain;
     let deployer: SandboxContract<TreasuryContract>;
+    let skipper: SandboxContract<TreasuryContract>;
+    let proposal: SandboxContract<TreasuryContract>;
+    let voter: SandboxContract<Voter>;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
         blockchain = await Blockchain.create();
 
         deployer = await blockchain.treasury('deployer');
+        skipper = await blockchain.treasury('skipper');
+        proposal = await blockchain.treasury('proposal');
+
+        voter = blockchain.openContract(await Voter.fromInit(skipper.address, proposal.address, deployer.address));
+    });
+    
+    it('should not double init voter', async () => {
+        let firstInitResult = await voter.send(
+            proposal.getSender(),
+            {
+                value: toNano("1"),
+            },
+            {
+                $$type: 'InitVoter',
+                amount: toNano("100"),
+            }
+        );
+        expect(firstInitResult.transactions).toHaveTransaction({
+            from: proposal.address,
+            to: voter.address,
+            success: true,
+            op: OP_CODES.InitVoter,
+        });
+
+        const secondInitResult = await voter.send(
+            proposal.getSender(),
+            {
+                value: toNano("1"),
+            },
+            {
+                $$type: 'InitVoter',
+                amount: toNano("200"),
+            }
+        );
+    
+        expect(secondInitResult.transactions).toHaveTransaction({
+            from: proposal.address,
+            to: voter.address,
+            success: false, 
+            exitCode: EXIT_CODES.AlreadyInitialized, 
+        });
     });
 
-    it('todo', async () => {
-        expect(2 + 2).toEqual(4);
+    it('should fail UpdateVoterBalance if voter is not initialized', async () => {
+        const updateBalanceResult = await voter.send(
+            skipper.getSender(),
+            {
+                value: toNano("1"),
+            },
+            {
+                $$type: 'UpdateVoterBalance',
+                amount: toNano("100"),
+                vote: BigInt(1),
+                voter_unlock_date: BigInt(Math.floor(Date.now() / 1000 + 3600)) 
+            }
+        );
+    
+        expect(updateBalanceResult.transactions).toHaveTransaction({
+            from: skipper.address,
+            to: voter.address,
+            success: false,
+            exitCode: EXIT_CODES.NotInitialized,
+        });
+    });
+    
+    it('should fail initialization from unauthorized sender', async () => {
+        const result = await voter.send(
+            deployer.getSender(),
+            { value: toNano("1") },
+            { $$type: 'InitVoter', amount: toNano("100") }
+        );
+
+        expect(result.transactions).toHaveTransaction({
+            success: false,
+            exitCode: EXIT_CODES.InvalidOwner,
+        });
+    });
+
+    it('should fail UpdateVoterBalance from unauthorized sender', async () => {
+        let firstInitResult = await voter.send(
+            proposal.getSender(),
+            {
+                value: toNano("1"),
+            },
+            {
+                $$type: 'InitVoter',
+                amount: toNano("100"),
+            }
+        );
+        expect(firstInitResult.transactions).toHaveTransaction({
+            from: proposal.address,
+            to: voter.address,
+            success: true,
+            op: OP_CODES.InitVoter,
+        });
+
+        const result = await voter.send(
+            proposal.getSender(),
+            { value: toNano("1") },
+            {
+                $$type: 'UpdateVoterBalance',
+                amount: toNano("100"),
+                vote: BigInt(1),
+                voter_unlock_date: BigInt(Math.floor(Date.now() / 1000 + 3600)),
+            }
+        );
+
+        expect(result.transactions).toHaveTransaction({
+            success: false,
+            exitCode: EXIT_CODES.InvalidOwner,
+        });
     });
 });

--- a/tests/Voter.spec.ts
+++ b/tests/Voter.spec.ts
@@ -92,26 +92,9 @@ describe('Voter', () => {
             success: false,
             exitCode: EXIT_CODES.InvalidOwner,
         });
-    });
+    });    
 
     it('should fail UpdateVoterBalance from unauthorized sender', async () => {
-        let firstInitResult = await voter.send(
-            proposal.getSender(),
-            {
-                value: toNano("1"),
-            },
-            {
-                $$type: 'InitVoter',
-                amount: toNano("100"),
-            }
-        );
-        expect(firstInitResult.transactions).toHaveTransaction({
-            from: proposal.address,
-            to: voter.address,
-            success: true,
-            op: OP_CODES.InitVoter,
-        });
-    
         // Unauthorized sender
         const result = await voter.send(
             proposal.getSender(),
@@ -170,7 +153,7 @@ describe('Voter', () => {
             from: skipper.address,
             to: voter.address,
             success: false,
-            exitCode: EXIT_CODES.VoteAlreadyCasted, // Expect vote already cast error
+            exitCode: EXIT_CODES.AlreadyInitialized, // Expect vote already cast error
         });
     });    
     

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -39,6 +39,5 @@ export const EXIT_CODES = {
     ProxyOPCodeNotFound: 6909,
     UnlockDateInsufficient: 6910,
     InvalidLockPeriod: 6911, 
-    LockPeriodTooShort: 6912,
-    VoteAlreadyCasted: 6913,
+    LockPeriodTooShort: 6912
 };

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -40,4 +40,5 @@ export const EXIT_CODES = {
     UnlockDateInsufficient: 6910,
     InvalidLockPeriod: 6911, 
     LockPeriodTooShort: 6912,
+    VoteAlreadyCasted: 6913,
 };

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -39,5 +39,6 @@ export const EXIT_CODES = {
     ProxyOPCodeNotFound: 6909,
     UnlockDateInsufficient: 6910,
     InvalidLockPeriod: 6911, 
-    LockPeriodTooShort: 6912
+    LockPeriodTooShort: 6912,
+    InvalidAmount: 6913
 };


### PR DESCRIPTION
## PR Summary
- **Voter Contract Updates:**
  - Added `is_initialized` to prevent double initialization.
  - Added `voted` to prevent double voting.

- **Voter Test Coverage:**
  - Initialization on first `UpdateVoterBalance` call
  - Unauthorized initialization and voting
  - Double initialization prevention
  - Voting increase
  - Voting with incorrect amount
