### PR TITLE
feat: add get_jetton_master getter to skipper

### DIFF
--- a/contracts/skipper.tact
+++ b/contracts/skipper.tact
@@ -71,6 +71,10 @@ contract Skipper with Deployable {
         let init = initOf JettonLock(owner, self.jetton_master);
         return contractAddress(init);
     }
+
+    get fun get_jetton_master(): Address {
+        return self.jetton_master;
+    }
     
     get fun get_proposal_address(proposal_id: Int): Address {
         let init = initOf Proposal(myAddress(), proposal_id);


### PR DESCRIPTION
**Summary of changes**:

I am still working on MVP of UI for Skipper. And i faced with problem that i can't find out what jetton are used for deployed DAO. I added getter `get_jetton_master` getter for it