### PR TITLE
fix: update TakeWalletAddress signature

### DIFF
--- a/contracts/lock.tact
+++ b/contracts/lock.tact
@@ -50,7 +50,7 @@ contract JettonLock with Deployable {
 
     receive(msg: TakeWalletAddress){
         nativeThrowUnless(ERROR_CODE_INVALID_OWNER, sender() == self.jetton_master);
-        nativeThrowUnless(ERROR_CODE_INVALID_OWNER, myAddress() == msg.owner_address);
+        // nativeThrowUnless(ERROR_CODE_INVALID_OWNER, myAddress() == msg.owner_address);
         self.owner_jetton_wallet = msg.wallet_address;
 
         let cached = self.unverified_data.get(msg.wallet_address);

--- a/contracts/messages.tact
+++ b/contracts/messages.tact
@@ -22,7 +22,7 @@ message(0x2c76b973) ProvideWalletAddress {
 message(0xd1735400) TakeWalletAddress {
     query_id: Int as uint64;
     wallet_address: Address;
-    owner_address: Address?;
+    owner_address: Slice as remaining;
 }
 /* Common structs */
 struct ProposalPayload {

--- a/tests/Lock.spec.ts
+++ b/tests/Lock.spec.ts
@@ -1,5 +1,5 @@
 import '@ton/test-utils';
-import { beginCell, comment, toNano } from '@ton/core';
+import { Address, beginCell, Cell, comment, toNano } from '@ton/core';
 import { Blockchain, SandboxContract, TreasuryContract  } from '@ton/sandbox';
 import { JettonLock } from '../wrappers/Lock';
 import { JettonMaster } from './JettonMaster';
@@ -452,5 +452,23 @@ describe('Error handling for lock', () => {
             op: OP_CODES.UnlockJettons,
             exitCode: EXIT_CODES.UnlockDateNotArrived,
         });
+    });
+
+    it('validate minter.ton.org jetton discovery', async () => {
+        const provideJettonWalletCell = Cell.fromHex("b5ee9c7201010101003000005b2c76b973000000000000000080121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c978");
+        const provideJettonWalletParser = provideJettonWalletCell.beginParse();
+        expect(provideJettonWalletParser.loadUint(32)).toEqual(OP_CODES.ProvideWalletAddress);
+        expect(provideJettonWalletParser.loadUint(64)).toEqual(0); // query_id
+        expect(provideJettonWalletParser.loadAddress()).toEqualAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"));
+        expect(provideJettonWalletParser.loadBit()).toEqual(true);
+        expect(provideJettonWalletParser.remainingBits).toEqual(0);
+        
+        const takeJettonWalletCell = Cell.fromHex("b5ee9c7201010201005500015bd1735400000000000000000080185c00699fb594fd4f969e4bcf464866d2620c1b9f4830ad24a1fc7072a733067801004380121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c970");
+        const takeJettonWalletParser = takeJettonWalletCell.beginParse();
+        expect(takeJettonWalletParser.loadUint(32)).toEqual(OP_CODES.TakeWalletAddress);
+        expect(takeJettonWalletParser.loadUint(64)).toEqual(0); // query_id
+        expect(takeJettonWalletParser.loadAddress()).toEqualAddress(Address.parse("kQDC4ANM_ayn6ny08l56MkM2kxBg3PpBhWklD-ODlTmYM0wm"));
+        const takeJettonWalletInner = takeJettonWalletParser.loadMaybeRef()?.beginParse();
+        expect(takeJettonWalletInner?.loadAddress()).toEqualAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"));
     });
 });

--- a/tests/Lock.spec.ts
+++ b/tests/Lock.spec.ts
@@ -238,6 +238,7 @@ describe('Success lock behavior', () => {
     });
 
     it('validate minter.ton.org jetton discovery 1', async () => {
+        // TX https://testnet.tonviewer.com/transaction/e80142e8e3215775636e8c748e5ee486f68690fd9e2737b48ee5341d92900ccc
         validateJettonDiscovery(
             Cell.fromHex("b5ee9c7201010101003000005b2c76b973000000000000000080121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c978"),
             Cell.fromHex("b5ee9c7201010201005500015bd1735400000000000000000080185c00699fb594fd4f969e4bcf464866d2620c1b9f4830ad24a1fc7072a733067801004380121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c970"),
@@ -247,6 +248,7 @@ describe('Success lock behavior', () => {
     });
 
     it('validate minter.ton.org jetton discovery 2', async () => {
+        // TX https://testnet.tonviewer.com/transaction/e597041abf9f766bfadbbec9a8b64e8b2975c418e2caa7f4a9aa78448ba1ed6d
         validateJettonDiscovery(
             Cell.fromHex("b5ee9c7201010101003000005b2c76b9730000000000000000800a00719576e4e04ed8f23109a9b4934f412ac824499d4a68155545c52b829baef8"),
             Cell.fromHex("b5ee9c7201010201005500015bd17354000000000000000000801186322fb8fbb745ba91becc67e7f69831988f98a58f7c3755e4230714c011ebf8010043800a00719576e4e04ed8f23109a9b4934f412ac824499d4a68155545c52b829baef0"),
@@ -255,8 +257,19 @@ describe('Success lock behavior', () => {
         );
     });
 
-    // Seems like Ston.fi Test jetton is broken, so we skip this test for now
+    it('validate random jetton discovery', async () => {
+        // TX https://testnet.tonviewer.com/transaction/07f2eb791c1c393d374dd817ea091e503cc764514e357d923884b32786a4f3fa
+        validateJettonDiscovery(
+            Cell.fromHex("b5ee9c7201010101003000005b2c76b9730000000000000000801cefb507b28f2b9a56974c3c476b608d5f6f2dae14958c625c4bcd7bc0f701aa78"),
+            Cell.fromHex("b5ee9c7201010201005500015bd17354000000000000000000800a6b85bdc324aa200130107757710c7e867ac57419075aa8d6ab857dad5f35f9d8010043801cefb507b28f2b9a56974c3c476b608d5f6f2dae14958c625c4bcd7bc0f701aa70"),
+            "EQBTXC3uGSVRAAmAg7q7iGP0M9YroMg61Ua1XCvtavmvzniK",
+            "EQDnfag9lHlc0rS6YeI7WwRq-3ltcKSsYxLiXmveB7gNUzNO",
+        );
+    });
+
+    // // Seems like Ston.fi Test jetton is broken, so we skip this test for now
     // it('validate Ston.fi Test RED jetton discovery', async () => {
+    //     // TX https://testnet.tonviewer.com/transaction/cfe69a34c1da4995c41a4906fbc33a3e8ffd02e0b733743500e16da47cf8fcff
     //     validateJettonDiscovery(
     //         Cell.fromHex("b5ee9c7201010101003000005b2c76b9730000000000000000801ac51523aa9f8e8c0e5e19e6325dd3fbcf1b1c79e722aaf6e9290e0576d00e58d8"),
     //         Cell.fromHex("b5ee9c72010102010034000119d17354000000000000000000c0010043801ac51523aa9f8e8c0e5e19e6325dd3fbcf1b1c79e722aaf6e9290e0576d00e58d0"),

--- a/tests/Lock.spec.ts
+++ b/tests/Lock.spec.ts
@@ -1,7 +1,7 @@
 import '@ton/test-utils';
 import { Address, beginCell, Cell, comment, toNano } from '@ton/core';
 import { Blockchain, SandboxContract, TreasuryContract  } from '@ton/sandbox';
-import { JettonLock } from '../wrappers/Lock';
+import { JettonLock, loadProvideWalletAddress, loadTakeWalletAddress } from '../wrappers/Lock';
 import { JettonMaster } from './JettonMaster';
 import { JettonWallet } from './JettonWallet';
 import { EXIT_CODES, LOCK_INTERVAL, OP_CODES, ZERO_ADDRESS } from './constants';
@@ -212,6 +212,26 @@ describe('Success lock behavior', () => {
             success: true,
             op: OP_CODES.JettonTransfer,
         });
+    });
+
+    it('validate minter.ton.org jetton discovery', async () => {
+        const provideJettonWalletCell = Cell.fromHex("b5ee9c7201010101003000005b2c76b973000000000000000080121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c978");
+        const parsedProvideJettonWallet = loadProvideWalletAddress(provideJettonWalletCell.asSlice());
+        expect(parsedProvideJettonWallet.$$type).toEqual('ProvideWalletAddress');
+        expect(parsedProvideJettonWallet.query_id).toEqual(0n);
+        expect(parsedProvideJettonWallet.owner_address).toEqualAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"));
+        expect(parsedProvideJettonWallet.include_address).toEqual(true);
+
+        const takeJettonWalletCell = Cell.fromHex("b5ee9c7201010201005500015bd1735400000000000000000080185c00699fb594fd4f969e4bcf464866d2620c1b9f4830ad24a1fc7072a733067801004380121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c970");
+        const parsedTakeJettonWallet = loadTakeWalletAddress(takeJettonWalletCell.asSlice());
+        expect(parsedTakeJettonWallet.$$type).toEqual("TakeWalletAddress");
+        expect(parsedTakeJettonWallet.query_id).toEqual(0n);
+        expect(parsedTakeJettonWallet.wallet_address).toEqualAddress(Address.parse("kQDC4ANM_ayn6ny08l56MkM2kxBg3PpBhWklD-ODlTmYM0wm"));
+        expect(parsedTakeJettonWallet.owner_address).toEqualSlice(
+            beginCell().storeMaybeRef(
+                beginCell().storeAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"))
+            ).asSlice()
+        );
     });
 });
 
@@ -452,23 +472,5 @@ describe('Error handling for lock', () => {
             op: OP_CODES.UnlockJettons,
             exitCode: EXIT_CODES.UnlockDateNotArrived,
         });
-    });
-
-    it('validate minter.ton.org jetton discovery', async () => {
-        const provideJettonWalletCell = Cell.fromHex("b5ee9c7201010101003000005b2c76b973000000000000000080121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c978");
-        const provideJettonWalletParser = provideJettonWalletCell.beginParse();
-        expect(provideJettonWalletParser.loadUint(32)).toEqual(OP_CODES.ProvideWalletAddress);
-        expect(provideJettonWalletParser.loadUint(64)).toEqual(0); // query_id
-        expect(provideJettonWalletParser.loadAddress()).toEqualAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"));
-        expect(provideJettonWalletParser.loadBit()).toEqual(true);
-        expect(provideJettonWalletParser.remainingBits).toEqual(0);
-        
-        const takeJettonWalletCell = Cell.fromHex("b5ee9c7201010201005500015bd1735400000000000000000080185c00699fb594fd4f969e4bcf464866d2620c1b9f4830ad24a1fc7072a733067801004380121b65243c0750380e7c2dd2cb85cd0d4e22bd80ca662b46528b5f177371f3c970");
-        const takeJettonWalletParser = takeJettonWalletCell.beginParse();
-        expect(takeJettonWalletParser.loadUint(32)).toEqual(OP_CODES.TakeWalletAddress);
-        expect(takeJettonWalletParser.loadUint(64)).toEqual(0); // query_id
-        expect(takeJettonWalletParser.loadAddress()).toEqualAddress(Address.parse("kQDC4ANM_ayn6ny08l56MkM2kxBg3PpBhWklD-ODlTmYM0wm"));
-        const takeJettonWalletInner = takeJettonWalletParser.loadMaybeRef()?.beginParse();
-        expect(takeJettonWalletInner?.loadAddress()).toEqualAddress(Address.parse("kQCQ2ykh4DqBwHPhbpZcLmhqcRXsBlMxWjKUWvi7m4-eS2ZU"));
     });
 });


### PR DESCRIPTION
**Summary of changes**:

This PR fixes parsing of the TakeWalletAddress message in the Lock contract to support the structure used by Jettons minted via [minter.ton.org](https://minter.ton.org/).

Closes #50 